### PR TITLE
PR: Fix 403 Errors and Improve Authentication Handling for Favorites and Suggestions

### DIFF
--- a/src/Analyzer/FavoritesAnalyzerResult.vue
+++ b/src/Analyzer/FavoritesAnalyzerResult.vue
@@ -41,7 +41,8 @@ import { cloneDeep, debounce } from "lodash";
 import * as Comlink from "comlink";
 import { useRoute } from "vue-router";
 import ProgressMessage from "@/Suggester/ProgressMessage.vue";
-import { useUrlStore } from "@/services";
+import { useUrlStore, useAccountStore } from "@/services";
+const account = useAccountStore();
 import { useHead } from "@unhead/vue";
 import TagLabel from "@/Tag/TagLabel.vue";
 
@@ -65,12 +66,18 @@ const args = computed<IAnalyzeTagsArgs>(() => {
 const result = ref<IAnalyzeTagsResult>();
 
 const analyze = debounce(async (a) => {
+  if (!account.auth) {
+    result.value = undefined;
+    progress.value = { message: "You must be logged in with an API key to analyze favorites.", progress: 1 };
+    return;
+  }
   const service = await getAnalyzeService();
   result.value = await service.analyzeTags(
     a,
     Comlink.proxy((progressEvent) => {
       progress.value = progressEvent;
     }),
+    account.auth,
   );
 }, 500);
 

--- a/src/Suggester/SuggesterResult.vue
+++ b/src/Suggester/SuggesterResult.vue
@@ -75,13 +75,14 @@ const result = ref<FavoriteTagsResult | null>(null);
 
 const analyze = async (username: string) => {
   const service = await getAnalyzeService();
-  result.value = await service.getFavoriteTags(
-    username,
-    urlStore.e621Url,
-    Comlink.proxy((progressEvent) => {
-      progress.value = progressEvent;
-    }),
-  );
+    result.value = await service.getFavoriteTags(
+      username,
+      urlStore.e621Url,
+      Comlink.proxy((progressEvent) => {
+        progress.value = progressEvent;
+      }),
+      toRaw(account.auth),
+    );
   await nextTick();
   await loadNextPage();
 };


### PR DESCRIPTION
## Summary
This PR addresses issues with 403 Forbidden errors when fetching favorite posts for analysis and suggestions. The root cause was missing or incorrect authentication (API key and username) when making API requests that require user credentials.

## Changes Made

- **FavoritesAnalyzerResult.vue**
  - Now checks if the user is logged in and has an API key before running analysis. If not, a user-friendly error message is shown instead of a 403 error.
  - Passes the user's authentication credentials to the analysis service.

- **SuggesterResult.vue**
  - Passes authentication credentials to the suggestion service for favorite post queries.

- **AnalyzeService.ts**
  - All relevant methods (`analyzeTags`, `getFavoriteTags`, `fetchPostsCached`) now accept and forward an optional `auth` parameter.
  - Ensures that API requests for `fav:username` tags are always authenticated.

---

This PR does not include any backend or API changes, only frontend logic and error handling improvements.